### PR TITLE
Infrared Lens images cannot be acquired when the aircraft is restarted.

### DIFF
--- a/examples/liveview/test_liveview_dual_main.cc
+++ b/examples/liveview/test_liveview_dual_main.cc
@@ -86,13 +86,18 @@ int main(int argc, char **argv) {
         fpv_liveview_sample->Start();
     }
 
-    if (argc == 4) {
-        auto src = atoi(argv[3]);
-        INFO("set camera soure: %d", src);
-        payload_liveview_sample->SetCameraSource((edge_sdk::Liveview::CameraSource)src);
-    }
 
     while (1) sleep(3);
+
+    while (1) 
+    {
+        if (argc == 4) {
+            auto src = atoi(argv[3]);
+            INFO("set camera soure: %d", src);
+            payload_liveview_sample->SetCameraSource((edge_sdk::Liveview::CameraSource)src);
+        }
+        sleep(3);
+    }
 
     return 0;
 }

--- a/examples/liveview/test_liveview_main.cc
+++ b/examples/liveview/test_liveview_main.cc
@@ -72,13 +72,15 @@ int main(int argc, char **argv) {
         liveview_sample->Start();
     }
 
-    if (argc == 4) {
-        auto src = atoi(argv[3]);
-        INFO("set camera soure: %d", src);
-        liveview_sample->SetCameraSource((edge_sdk::Liveview::CameraSource)src);
+    while (1) 
+    {
+        if (argc == 4) {
+            auto src = atoi(argv[3]);
+            INFO("set camera soure: %d", src);
+            liveview_sample->SetCameraSource((edge_sdk::Liveview::CameraSource)src);
+        }
+        sleep(3);
     }
-
-    while (1) sleep(3);
 
     return 0;
 }


### PR DESCRIPTION
**Describe the bug**
Infrared Lens images cannot be acquired when the aircraft is restarted.


**To Reproduce**
Steps to reproduce the behavior:
1. Connect Edge PC and Dock2.(Execute with ./build/bin/test_liveview 1 1 3)
2. Launch aircraft.

or

1. Launch aircraft.
2. Connect Edge PC and Dock2.(Execute with ./build/bin/test_liveview 1 1 3)
3. Reboot aircraft.

**Expected behavior**
Get Infrared Lens images.


**Describe alternatives considered**
Reset camera soure every 3 seconds